### PR TITLE
add tooltip to map icons

### DIFF
--- a/js/somemap.js
+++ b/js/somemap.js
@@ -174,6 +174,25 @@ function geoJson_data_init(geoJs){
       infowindowdom.innerHTML = infowindow_compiled({'prop':self.prop});
       $(infowindowdom).addClass("activating");
     });
+
+    marker.addListener('mouseover', function() {
+      var self = this;
+
+      self.__tooltip = new google.maps.InfoWindow({
+        content: self.prop.Name
+      });
+
+      self.__tooltip.open(map, this);
+    });
+
+    marker.addListener("mouseout", function() {
+      var self = this;
+
+      if (self.__tooltip) {
+        self.__tooltip.close();
+      }
+    });
+
     markers.push(marker);
   }
   // if(carousel_inner_html === ''){


### PR DESCRIPTION
This fix wasn't as easy as #90. Let me know if you think this solution is "good enough". I have a concern the ui of the tooltip because there is a close icon that user can't click.

<img width="1240" alt="screen shot 2016-08-15 at 4 19 18 pm" src="https://cloud.githubusercontent.com/assets/1700158/17680066/0969ee40-6304-11e6-8391-2cd0bd945655.png">
