### PR TITLE
Reveal myth answer on mobile touch

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,6 +307,11 @@ $(document).ready(function(){
     } // End if
   });
 
+  // Toggle Myth answers on "True?" mobile touch
+  $('.ok-myth-question').on("touchstart", function (e) {
+    e.preventDefault();
+  });
+
   $(window).scroll(function() {
     $(".slideanim").each(function(){
       var pos = $(this).offset().top;


### PR DESCRIPTION
Work performed during Code For America - Hack Night (2016-08-15)

This PR adds mobile touch support to reveal the myth answers when tapping the "True?" button. Tapping one "True?" button hides the answer for the other answer, similar to an HTML radio button.

Tested on mobile Safari via iOS Emulator (iOS 8.1)
[View recording](http://imgur.com/a/mVfPU)

Tested on Android via Android Emulator (4.4 KitKat)
[View recording](http://imgur.com/a/tG28Z)

I'm not entirely sure why simply adding the `touchstart` event to those elements has the same hover-effect as desktop but ¯\_(ツ)_/¯

Fixes #94 
