### PR TITLE
Translation Myths to Spanish

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
         <li><a class="l10n" data-lkey="UpcomingEvents" href="#events">Events</a></li>
         <li><a class="l10n" data-lkey="STDTreatment" href="#stdtreatment">STD Treatment</a></li>
         <li><a class="l10n" data-lkey="STDSymptoms" href="#stdinfo">STD Symptoms</a></li>
-        <li><a href="#myth">STD Myths</a></li>  
+        <li><a href="#myth" class="l10n" data-lkey="MythNav">STD Myths</a></li>
         <li><a class="l10n" data-lkey="About" href="#about">About</a></li>
       </ul>
     </div>
@@ -149,71 +149,71 @@
 <div class="container-fluid" id="myth">
   <div class="row">
     <div class="col-sm-12">
-        <h2>STD Myths and Facts</h2>
-        <h3>Urban legends and facts about sexually transmitted diseases</h3>
+        <h2 class="l10n" data-lkey="MythHeading">STD Myths and Facts</h2>
+        <h3 class="l10n" data-lkey="MythSubheading">Urban legends and facts about sexually transmitted diseases</h3>
         <div class="row">
             <dl class="ok-std-myths">
-                <dt>If a woman feels burning when <strong>earwax</strong> is put in her vagina she has an STD. 
+                <dt><span class="l10n" data-lkey="MythEarwaxQ">If a woman feels burning when <strong>earwax</strong> is put in her vagina she has an STD.</span>
                 <hr /></dt>
-                <dd>This myth, known as the <strong>STD prison test, is FALSE</strong>.
-                    <a class="ok-myth-question">True?</a>
-                    <a class="ok-myth-question-false">False!</a>
+                <dd><span class="l10n" data-lkey="MythEarwaxA">This myth, known as the <strong>STD prison test, is FALSE</strong>.</span>
+                    <a class="ok-myth-question l10n" data-lkey="trueq">True?</a>
+                    <a class="ok-myth-question-false l10n" data-lkey="falsex">False!</a>
                 </dd>
                 
-                <dt><strong>Chlamydia</strong> is the most commonly reported STD infection in the USA.
+                <dt><span class="l10n" data-lkey="MythChlamydiaQ"><strong>Chlamydia</strong> is the most commonly reported STD infection in the USA.</span>
                 <hr /></dt>
-                <dd class="ok-std-myths-truth">The most commonly reported infection is indeed <strong>chlamydia</strong>. <strong>Gonorrhea</strong> is the second most commonly reported STD in the United States. 
-                    <a class="ok-myth-question">True?</a>
-                    <a class="ok-myth-question-true">True!</a>
+                <dd class="ok-std-myths-truth"><span class="l10n" data-lkey="MythChlamydiaA">The most commonly reported infection is indeed <strong>chlamydia</strong>. <strong>Gonorrhea</strong> is the second most commonly reported STD in the United States.</span>
+                    <a class="ok-myth-question l10n" data-lkey="trueq">True?</a>
+                    <a class="ok-myth-question-true l10n" data-lkey="truex">True!</a>
                 </dd>                   
                 
-                <dt>Using <strong>two condoms</strong> prevents STDs. 
+                <dt><span class="l10n" data-lkey="MythTwoCondomsQ">Using <strong>two condoms</strong> prevents STDs.</span>
                 <hr /></dt>
-                <dd>In this case, less is more. <strong>Use only one condom</strong> every time you engage in sex.
-                    <a class="ok-myth-question">True?</a>
-                    <a class="ok-myth-question-false">False!</a>
+                <dd><span class="l10n" data-lkey="MythTwoCondomsA">In this case, less is more. <strong>Use only one condom</strong> every time you engage in sex.</span>
+                    <a class="ok-myth-question l10n" data-lkey="trueq">True?</a>
+                    <a class="ok-myth-question-false l10n" data-lkey="falsex">False!</a>
                 </dd>   
                 
-                <dt>An STD known as <strong>Blue Waffle Disease</strong> causes burning, itching, blue discoloration and discharge, and swelling of the vagina. 
+                <dt><span class="l10n" data-lkey="MythBlueWaffleQ">An STD known as <strong>Blue Waffle Disease</strong> causes burning, itching, blue discoloration and discharge, and swelling of the vagina.</span>
                 <hr /></dt>
-                <dd>Blue Waffle Disease is many things, but real is not one of them. It is an urban legend about a <strong>fictional STD</strong>.
-                    <a class="ok-myth-question">True?</a>
-                    <a class="ok-myth-question-false">False!</a>
+                <dd><span class="l10n" data-lkey="MythBlueWaffleA">Blue Waffle Disease is many things, but real is not one of them. It is an urban legend about a <strong>fictional STD</strong>.</span>
+                    <a class="ok-myth-question l10n" data-lkey="trueq">True?</a>
+                    <a class="ok-myth-question-false l10n" data-lkey="falsex">False!</a>
                 </dd>                 
                 
-                <dt><strong>Teenagers</strong> can receive testing and treatment for STDs without having their parents notified.
+                <dt><span class="l10n" data-lkey="MythNoParentsQ"><strong>Teenagers</strong> can receive testing and treatment for STDs without having their parents notified.</span>
                 <hr /></dt>
-                <dd class="ok-std-myths-truth"><strong>True.</strong> In Missouri, minors 14 years and older can be tested and treated for STDs without a parent's permission or notification. 
-                    <a class="ok-myth-question">True?</a>
-                    <a class="ok-myth-question-true">True!</a>
+                <dd class="ok-std-myths-truth"><span class="l10n" data-lkey="truex">True.</span> <span class="l10n" data-lkey="MythNoParentsA">In Missouri, minors 14 years and older can be tested and treated for STDs without a parent's permission or notification.</span>
+                    <a class="ok-myth-question l10n" data-lkey="trueq">True?</a>
+                    <a class="ok-myth-question-true l10n" data-lkey="truex">True!</a>
                 </dd>                   
                 
-                <dt>More than 1.2 million people in the US are living with <strong>HIV</strong>.
+                <dt><span class="l10n" data-lkey="MythHIVQ">More than 1.2 million people in the US are living with <strong>HIV</strong>.</span>
                 <hr /></dt>
-                <dd class="ok-std-myths-truth">More than 1.2 million people in the US are living with HIV, and <strong>1 in 8 of them don’t know it</strong>.
-                    <a class="ok-myth-question">True?</a>
-                    <a class="ok-myth-question-true">True!</a>
+                <dd class="ok-std-myths-truth"><span class="l10n" data-lkey="MythHIVA">More than 1.2 million people in the US are living with HIV, and <strong>1 in 8 of them don’t know it</strong>.</span>
+                    <a class="ok-myth-question l10n" data-lkey="trueq">True?</a>
+                    <a class="ok-myth-question-true l10n" data-lkey="truex">True!</a>
                 </dd>                 
                 
-                <dt>You can't tell if someone has an STD by <strong>looking at them</strong>.
+                <dt><span class="l10n" data-lkey="MythLookingQ">You can't tell if someone has an STD by <strong>looking at them</strong>.</span>
                 <hr /></dt>
-                <dd class="ok-std-myths-truth">True. People can and do have STDs without having <strong>any symptoms</strong>. 
-                    <a class="ok-myth-question">True?</a>
-                    <a class="ok-myth-question-true">True!</a>
+                <dd class="ok-std-myths-truth"><span class="l10n" data-lkey="truex">True.</span> <span class="l10n" data-lkey="MythLookingA">People can and do have STDs without having <strong>any symptoms</strong>.</span>
+                    <a class="ok-myth-question l10n" data-lkey="trueq">True?</a>
+                    <a class="ok-myth-question-true l10n" data-lkey="truex">True!</a>
                 </dd>                  
                 
-                <dt>STDs can be spread by sharing <strong>toilet seats</strong>. 
+                <dt><span class="l10n" data-lkey="MythTolietSeatsQ">STDs can be spread by sharing <strong>toilet seats</strong>.</span>
                 <hr /></dt>
-                <dd>STDs are contracted by <strong>sexual contact</strong> (generally speaking).
-                    <a class="ok-myth-question">True?</a>
-                    <a class="ok-myth-question-false">False!</a>
+                <dd><span class="l10n" data-lkey="MythTolietSeatsA">STDs are contracted by <strong>sexual contact</strong> (generally speaking).</span>
+                    <a class="ok-myth-question l10n" data-lkey="trueq">True?</a>
+                    <a class="ok-myth-question-false l10n" data-lkey="falsex">False!</a>
                 </dd>                
                 
-                <dt>It's important to <strong>wait to have sex</strong> after getting tested until more accurate test results can be obtained.
+                <dt><span class="l10n" data-lkey="MythAccurateQ">It's important to <strong>wait to have sex</strong> after getting tested until more accurate test results can be obtained.</span>
                 <hr /></dt>
-                <dd class="ok-std-myths-truth">It takes time for STDs to appear in the system. <strong>Chlamydia</strong> and <strong>Gonorrhea</strong> take  2-3 weeks, <strong>HIV</strong> and <strong>Syphilis</strong> take 12 weeks, and <strong>Herpes</strong> and <strong>Genital warts</strong> can only be tested during an outbreak.
-                    <a class="ok-myth-question">True?</a>
-                    <a class="ok-myth-question-true">True!</a>
+                <dd class="ok-std-myths-truth"><span class="l10n" data-lkey="MythAccurateA">It takes time for STDs to appear in the system. <strong>Chlamydia</strong> and <strong>Gonorrhea</strong> take  2-3 weeks, <strong>HIV</strong> and <strong>Syphilis</strong> take 12 weeks, and <strong>Herpes</strong> and <strong>Genital warts</strong> can only be tested during an outbreak.</span>
+                    <a class="ok-myth-question l10n" data-lkey="trueq">True?</a>
+                    <a class="ok-myth-question-true l10n" data-lkey="truex">True!</a>
                 </dd>                  
             </dl>
         </div>


### PR DESCRIPTION
Added markup for translating all Myth section headings, questions and answers. Not all sections have Spanish translations in the Spreadsheet. However I added markup so when they are entered in the spreadsheet they will appear on the site:
- Myth 2 question/answer in columns `CT` and `CU`
- Myth anchor text link in top nav in column `DA`
- Myth section heading in column `DB`
- Myth section subheading in column `DC`

Once the above translations are added this fixes ticket #103
