### PR TITLE
Collapse hospital cards on mobile

### DIFF
--- a/css/igotmine.css
+++ b/css/igotmine.css
@@ -196,6 +196,30 @@ a:hover {
     background: url("../images/igmikc-map-icon-treatment.png") no-repeat 2px 2px, #e1e1e1;
     transition: all 0.15s linear 0s;  
 }
+.treatment-more, .treatment-less {
+    display:none;
+}
+.treatment-headline {
+    background:none;
+}
+.treatment-toggleable {
+    display:block;
+}
+@media print, screen and (max-width: 740px) {
+    #std-treatment-list-section .ok-treatment {
+        height:auto;
+    }
+    .treatment-headline {
+        background: url("../images/igmikc-map-icon-treatment.png") no-repeat;
+        padding-left: 38px;
+    }
+    .treatment-more {
+        display:block;
+    }
+    .treatment-less, .treatment-toggleable {
+        display:none;
+    }
+}
 
 [data-type="condom"]:hover {
     padding: 8px 15px 8px 40px;

--- a/index.html
+++ b/index.html
@@ -138,8 +138,8 @@
     <div class="col-sm-12">
       <h2 class="l10n" data-lkey="STDSymptoms">STD Symptoms</h2>
       <h3 class="l10n" data-lkey="STDSymptomsCaption">Symptoms of common sexually transmitted diseases</h3>
-    <h3 class="ok-warning-message"><span class="ok-warning l10n" data-lkey="Warning">Warning</span> <span class="l10n ok-nowrap" data-lkey="ExplicitImages">Explicit Images</span>    
-    </h3>
+      <h3 class="ok-warning-message"><span class="ok-warning l10n" data-lkey="Warning">Warning</span> <span class="l10n ok-nowrap" data-lkey="ExplicitImages">Explicit Images</span>
+      </h3>
       <div id="std-card-list-section" class="row text-center">  
       </div>
     </div>

--- a/js/somemap.js
+++ b/js/somemap.js
@@ -117,12 +117,16 @@ var event_carousel_template_compiled = _.template(
 );
 var stdlocation_compiled = _.template(
   '<div class="ok-treatment">'+
-  '<h5><%= prop.Name %></h5>'+
+  '<h5 class="treatment-headline"><%= prop.Name %></h5>'+
   '<address><%= prop.Address %></address>'+
+  '<a href="#" class="treatment-more">More Details</a>'+
+  '<a href="#" class="treatment-less">Less Details</a>'+
+  '<div class="treatment-toggleable">'+
   't: <a href="tel:<%= prop.PhoneNumber %>"><%= prop.PhoneNumber %></a><br />'+
   '<time><span class="l10n" data-lkey="<%= prop.Days %>"><%= prop.Days %></span> <%= prop.Hours %></time>'+
   '<section class="treatment-details"><strong class="l10n" data-lkey="Treated">Treated</strong>: <span class="l10n" data-lkey="<%= prop.LocalizationKey %>Treatment"><%= prop.Details %></span></section><br />'+
   '<button type="button" class="btn btn-secondary show-marker center-block l10n" data-type="treatment" data-id="<%= prop.id %>" data-lkey="ViewOnMap">view on map</button>'+
+  '</div>'+
   '</div>'
 );
 var infowindowdom = document.getElementById('info-window');
@@ -330,5 +334,27 @@ $(document).ready(function() {
     }, 1000);
     show_marker_by_id($(e.target).data('id'));
     return false;
+  });
+  $('#std-treatment-list-section').on('click', '.treatment-more', function (e) {
+    e.preventDefault();
+    var self = $(this);
+    self.hide();
+    // TODO: Better target .treatment-less node
+    self.next().show();
+    // TODO: Better target .treatment-details node
+    self.next().next().show(200);
+    // TODO: Better target h5
+    self.prev().prev().removeClass('treatment-headline');
+  });
+  $('#std-treatment-list-section').on('click', '.treatment-less', function (e) {
+    e.preventDefault();
+    var self = $(this);
+    self.hide();
+    // TODO: Better target .treatment-more node
+    self.prev().show();
+    // TODO: Better target .treatment-details node, else when we change HTML it will break
+    self.next().hide(200);
+    // TODO: Better target h5
+    self.prev().prev().prev().addClass('treatment-headline');
   });
 });


### PR DESCRIPTION
Partial implementation for ticket #107.

This PR adds CSS to collapse treatment hospital cards when viewed on mobile or any device whose viewport is < 740px.

A link "More Details" displays the hospital telephone and text when clicked/tapped. The hospital icon next to the title is also hidden. A link "Less Details" then hides the same details and restores the hospital icon.

Collapsed mobile:
![Collapsed](http://i.imgur.com/ea27NOi.png)

Expanded mobile:
![Expanded](http://i.imgur.com/jDjg5US.png)

When viewport >= 740px the cards appear expanded and no More/Less Details link appear.

TODO after merge:
- On mobile, when card expanded, the button "View On Map" appears floating over the hospital text. See above "Expanded" image for example.
- The jQuery code to target HTML elements like the More/Less Details link and the hospital name heading are very fragile and coupled to the exact HTML structure. It would be better if these elements were targeted dynamically by CSS class.
- Hiding the hospital icon that appears next to the hospital name on-tap feels slightly jarring to me because the heading text instantly moves when the icon is removed. This movement causes my eye to instantly focus on the hospital name, which is taking the eye away from the important information, which is the details text being displayed. I added a slight animation to the show/hide expansion of hospital text to decrease its jarring effect and guide the eye to it. I think allowing the icon to remain next to the heading would result in less surprise and less distraction when viewing the details.

Thanks!
🚀 
